### PR TITLE
Typed storage - Class Attribute Based Configuration

### DIFF
--- a/DnetIndexedDb.sln
+++ b/DnetIndexedDb.sln
@@ -7,6 +7,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DnetIndexedDbServer", "samp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DnetIndexedDb", "src\DnetIndexedDb\DnetIndexedDb.csproj", "{3C35A46B-4E0C-463F-A2F7-F770A20257CB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9679AB81-8795-40C5-A210-B175C40F355D}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/samples/ServerSide/Infrastructure/Entities/TableFieldDto.cs
+++ b/samples/ServerSide/Infrastructure/Entities/TableFieldDto.cs
@@ -1,6 +1,4 @@
 ﻿using DnetIndexedDb;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace DnetIndexedDbServer.Infrastructure.Entities
 {

--- a/samples/ServerSide/Infrastructure/Entities/TableFieldDto.cs
+++ b/samples/ServerSide/Infrastructure/Entities/TableFieldDto.cs
@@ -1,28 +1,30 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using DnetIndexedDb;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace DnetIndexedDbServer.Infrastructure.Entities
 {
     public class TableFieldDto
     {
-        [Key]
+        [IndexDbKey(AutoIncrement = true)]
         public int? TableFieldId { get; set; }
-
+        [IndexDbIndex]
         public string TableName { get; set; }
-
+        [IndexDbIndex]
         public string FieldVisualName { get; set; }
-
+        [IndexDbIndex]
         public string AttachedProperty { get; set; }
-
+        [IndexDbIndex]
         public bool IsLink { get; set; }
-
+        [IndexDbIndex]
         public int MemberOf { get; set; }
-
+        [IndexDbIndex]
         public int Width { get; set; }
-
+        [IndexDbIndex]
         public string TextAlignClass { get; set; }
-
+        [IndexDbIndex]
         public bool Hide { get; set; }
-
+        [IndexDbIndex]
         public string Type { get; set; }
     }
 }

--- a/samples/ServerSide/Infrastructure/GridColumnDataIndexedDb2.cs
+++ b/samples/ServerSide/Infrastructure/GridColumnDataIndexedDb2.cs
@@ -1,0 +1,12 @@
+﻿using DnetIndexedDb;
+using Microsoft.JSInterop;
+
+namespace DnetIndexedDbServer.Infrastructure
+{
+    public class GridColumnDataIndexedDb2 : IndexedDbInterop
+    {
+        public GridColumnDataIndexedDb2(IJSRuntime jsRuntime, IndexedDbOptions<GridColumnDataIndexedDb2> options) : base(jsRuntime, options)
+        {
+        }
+    }
+}

--- a/samples/ServerSide/Pages/Index.razor
+++ b/samples/ServerSide/Pages/Index.razor
@@ -6,6 +6,7 @@
 @inject IJSRuntime JSRuntime
 
 @inject GridColumnDataIndexedDb GridColumnDataIndexedDb
+@inject GridColumnDataIndexedDb2 GridColumnDataIndexedDb2
 @inject SecuritySuiteDataIndexedDb SecuritySuiteDataIndexedDb
 
 <div class="dnet-desktop-content destok-layout" style="padding-top: 10px;">
@@ -26,7 +27,8 @@
     {
         if (firstRender)
         {
-            await InlineKeys();
+            //await InlineKeys();
+            await TestAttributes();
             //await InlineKeysPlusKeyGenerator();
             //await OutOfLinekeys();
             //await InlineKeysTwoDatabases();
@@ -105,6 +107,45 @@
         var testMinIndexEmpty = await GridColumnDataIndexedDb.GetMinIndex<string>("TableFieldDtos", "tableFieldId");
 
         var db1Result11 = await GridColumnDataIndexedDb.DeleteIndexedDb();
+    }
+
+    private async Task TestAttributes()
+    {
+        var tableFieldService = new TableFieldService();
+
+        var itemsDb1 = tableFieldService.GetTableFields();
+
+        var db1Result = await GridColumnDataIndexedDb2.OpenIndexedDb();
+
+        if (db1Result != -1)
+        {
+            var db1Result1 = await GridColumnDataIndexedDb2.DeleteAll<TableFieldDto>();
+        }
+
+        var db1Result2 = await GridColumnDataIndexedDb2.AddItems<TableFieldDto>(itemsDb1);
+
+        var db1Result3 = await GridColumnDataIndexedDb2.GetByKey<int, TableFieldDto>(11);
+
+        var db1Result4 = await GridColumnDataIndexedDb2.DeleteByKey<int, TableFieldDto>(11);
+
+        var db1Result5 = await GridColumnDataIndexedDb2.GetAll<TableFieldDto>();
+
+        var db1Result6 = await GridColumnDataIndexedDb2.GetRange<int, TableFieldDto>(15, 20);
+
+        foreach (var item in db1Result5)
+        {
+            item.FieldVisualName = item.FieldVisualName + "Updated";
+        }
+
+        var db1Result7a = await GridColumnDataIndexedDb2.UpdateItems<TableFieldDto>(db1Result5.ToList());
+
+        var db1Result8 = await GridColumnDataIndexedDb2.GetByIndex<int, TableFieldDto>(11, 18, "tableFieldId", true);
+
+        var db1Result9 = await GridColumnDataIndexedDb2.GetByIndex<int?, TableFieldDto>(11, null, "tableFieldId", false);
+
+        var db1Result10 = await GridColumnDataIndexedDb2.DeleteAll<TableFieldDto>();
+
+        var db1Result11 = await GridColumnDataIndexedDb2.DeleteIndexedDb();
     }
 
     //***in-line-keys using Key generators***

--- a/samples/ServerSide/Pages/Index.razor
+++ b/samples/ServerSide/Pages/Index.razor
@@ -143,6 +143,14 @@
 
         var db1Result9 = await GridColumnDataIndexedDb2.GetByIndex<int?, TableFieldDto>(11, null, "tableFieldId", false);
 
+        var testMaxKeyEmpty = await GridColumnDataIndexedDb.GetMaxKey<int, TableFieldDto>();
+
+        var testMinKeyEmpty = await GridColumnDataIndexedDb.GetMinKey<int, TableFieldDto>();
+
+        var testMaxIndexEmpty = await GridColumnDataIndexedDb.GetMaxIndex<string, TableFieldDto>("tableFieldId");
+
+        var testMinIndexEmpty = await GridColumnDataIndexedDb.GetMinIndex<string, TableFieldDto>("tableFieldId");
+
         var db1Result10 = await GridColumnDataIndexedDb2.DeleteAll<TableFieldDto>();
 
         var db1Result11 = await GridColumnDataIndexedDb2.DeleteIndexedDb();

--- a/samples/ServerSide/Startup.cs
+++ b/samples/ServerSide/Startup.cs
@@ -37,11 +37,7 @@ namespace DnetIndexedDbServer
 
             services.AddIndexedDbDatabase<GridColumnDataIndexedDb2>(options =>
             {
-                var indexedDbDatabaseModel = new IndexedDbDatabaseModel()
-                    .WithName("TestAttributes")
-                    .WithVersion(1);
-
-                indexedDbDatabaseModel.AddStore<TableFieldDto>();
+                var indexedDbDatabaseModel = GetGridColumnDatabaseModelAttributeBased();
 
                 options.UseDatabase(indexedDbDatabaseModel);
             });
@@ -80,7 +76,9 @@ namespace DnetIndexedDbServer
 
         private IndexedDbDatabaseModel GetGridColumnDatabaseModelAttributeBased()
         {
-            var indexedDbDatabaseModel = new IndexedDbDatabaseModel();
+            var indexedDbDatabaseModel = new IndexedDbDatabaseModel()
+                .WithName("TestAttributes")
+                .WithVersion(1);
 
             indexedDbDatabaseModel.AddStore<TableFieldDto>();
 

--- a/samples/ServerSide/Startup.cs
+++ b/samples/ServerSide/Startup.cs
@@ -3,6 +3,7 @@ using DnetIndexedDb;
 using DnetIndexedDb.Fluent;
 using DnetIndexedDb.Models;
 using DnetIndexedDbServer.Infrastructure;
+using DnetIndexedDbServer.Infrastructure.Entities;
 using DnetIndexedDbServer.Shared.Kylar;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -34,11 +35,16 @@ namespace DnetIndexedDbServer
                 options.UseDatabase(GetGridColumnDatabaseModel());
             });
 
-            //var model = new TableFieldDatabase();
-            //services.AddIndexedDbDatabase<GridColumnDataIndexedDb>(options =>
-            //{
-            //    options.UseDatabase(model);
-            //});
+            services.AddIndexedDbDatabase<GridColumnDataIndexedDb2>(options =>
+            {
+                var indexedDbDatabaseModel = new IndexedDbDatabaseModel()
+                    .WithName("TestAttributes")
+                    .WithVersion(1);
+
+                indexedDbDatabaseModel.AddStore<TableFieldDto>();
+
+                options.UseDatabase(indexedDbDatabaseModel);
+            });
 
             var model1 = new SecurityDatabase();
             services.AddIndexedDbDatabase<SecuritySuiteDataIndexedDb>(options =>
@@ -54,7 +60,7 @@ namespace DnetIndexedDbServer
                 app.UseDeveloperExceptionPage();
             }
             else
-            {  
+            {
                 app.UseExceptionHandler("/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
@@ -70,6 +76,15 @@ namespace DnetIndexedDbServer
                 endpoints.MapBlazorHub();
                 endpoints.MapFallbackToPage("/_Host");
             });
+        }
+
+        private IndexedDbDatabaseModel GetGridColumnDatabaseModelAttributeBased()
+        {
+            var indexedDbDatabaseModel = new IndexedDbDatabaseModel();
+
+            indexedDbDatabaseModel.AddStore<TableFieldDto>();
+
+            return indexedDbDatabaseModel;
         }
 
         private IndexedDbDatabaseModel GetGridColumnDatabaseModel()
@@ -311,7 +326,7 @@ namespace DnetIndexedDbServer
                 .AddIndex("tableName")
                 .AddIndex("textAlignClass")
                 .AddIndex("type")
-                .AddIndex("width");           
+                .AddIndex("width");
 
             return model;
         }

--- a/src/DnetIndexedDb/Attributes/IndexDbIndexAttribute.cs
+++ b/src/DnetIndexedDb/Attributes/IndexDbIndexAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DnetIndexedDb
+{
+    public class IndexDbIndexAttribute : Attribute
+    {
+        public bool Unique { get; set; } = false;
+        public string Name { get; set; }
+    }
+}

--- a/src/DnetIndexedDb/Attributes/IndexDbKeyAttribute.cs
+++ b/src/DnetIndexedDb/Attributes/IndexDbKeyAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DnetIndexedDb
+{
+    public class IndexDbKeyAttribute : Attribute
+    {
+        public string Name { get; set; }
+        public bool AutoIncrement { get; set; } = false;
+        public bool Unique { get; set; } = true;
+    }
+}

--- a/src/DnetIndexedDb/DnetIndexedDb.xml
+++ b/src/DnetIndexedDb/DnetIndexedDb.xml
@@ -36,6 +36,7 @@
             <param name="name"></param>
             <returns></returns>
         </member>
+        <!-- Badly formed XML comment ignored for member "M:DnetIndexedDb.Fluent.IndexedDbDatabaseExtensions.AddStore``1(DnetIndexedDb.Models.IndexedDbDatabaseModel)" -->
         <member name="M:DnetIndexedDb.Fluent.IndexedDbStoreExtensions.WithKey(DnetIndexedDb.Models.IndexedDbStore,System.String)">
             <summary>
             Add non-auto-incrementing key to store.
@@ -68,6 +69,14 @@
             <param name="name"></param>
             <returns>Given IndexedDbStore Instance</returns>
         </member>
+        <member name="M:DnetIndexedDb.Fluent.IndexedDbStoreExtensions.SetupFrom``1(DnetIndexedDb.Models.IndexedDbStore)">
+            <summary>
+            Adds Key and Indexes to Store based on IndexedDbKey and IndexedDbIndex Attributes on properties in Type T
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="store"></param>
+            <returns></returns>
+        </member>
         <member name="M:DnetIndexedDb.IndexedDbInterop.OpenIndexedDb">
             <summary>
             Create, Open or Upgrade IndexedDb Database
@@ -84,8 +93,16 @@
             <summary>
             Add records to a given data store
             </summary>
-            <typeparam name="TEntity"></typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="objectStoreName"></param>
+            <param name="items"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.AddItems``1(System.Collections.Generic.List{``0})">
+            <summary>
+            Add records to a data store matching TEntity.Name
+            </summary>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="items"></param>
             <returns></returns>
         </member>
@@ -93,17 +110,34 @@
             <summary>
             Update records in a given data store
             </summary>
-            <typeparam name="TEntity"></typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="objectStoreName"></param>
+            <param name="items"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.UpdateItems``1(System.Collections.Generic.List{``0})">
+            <summary>
+            Update records in a data store matching TEntity.Name
+            </summary>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="items"></param>
             <returns></returns>
         </member>
         <member name="M:DnetIndexedDb.IndexedDbInterop.UpdateItemsByKey``1(System.String,System.Collections.Generic.List{``0},System.Collections.Generic.List{System.Int32})">
             <summary>
-            Update records in a given data store by keys
+            Update records in a given data store by key
             </summary>
-            <typeparam name="TEntity"></typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="objectStoreName"></param>
+            <param name="items"></param>
+            <param name="keys"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.UpdateItemsByKey``1(System.Collections.Generic.List{``0},System.Collections.Generic.List{System.Int32})">
+            <summary>
+            Update records in a data store matching TEntity.Name by key
+            </summary>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="items"></param>
             <param name="keys"></param>
             <returns></returns>
@@ -112,19 +146,37 @@
             <summary>
             Return a record in a given data store by its key
             </summary>
-            <typeparam name="TEntity"></typeparam>
-            <typeparam name="TKey"></typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+            <typeparam name="TKey">Type of Key Field</typeparam>
             <param name="key"></param>
             <param name="objectStoreName"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.GetByKey``2(``0)">
+            <summary>
+            Return a record in a data store matching TEntity.Name by key
+            </summary>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+            <typeparam name="TKey">Type of Key Field</typeparam>
+            <param name="key"></param>
             <returns></returns>
         </member>
         <member name="M:DnetIndexedDb.IndexedDbInterop.DeleteByKey``1(System.String,``0)">
             <summary>
             Delete a record in a given data store by its key
             </summary>
-            <typeparam name="TKey"></typeparam>
+            <typeparam name="TKey">Type of Key Field</typeparam>
             <param name="key"></param>
             <param name="objectStoreName"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.DeleteByKey``2(``0)">
+            <summary>
+            Delete a record in a data store matching TEntity.Name by key
+            </summary>
+            <typeparam name="TKey">Type of Key Field</typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+            <param name="key"></param>
             <returns></returns>
         </member>
         <member name="M:DnetIndexedDb.IndexedDbInterop.DeleteAll(System.String)">
@@ -134,21 +186,45 @@
             <param name="objectStoreName"></param>
             <returns></returns>
         </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.DeleteAll``1">
+            <summary>
+            Delete all records in a data store matching TEntity.Name
+            </summary>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+            <returns></returns>
+        </member>
         <member name="M:DnetIndexedDb.IndexedDbInterop.GetAll``1(System.String)">
             <summary>
             Return all records in a given data store
             </summary>
-            <typeparam name="TEntity"></typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="objectStoreName"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.GetAll``1">
+            <summary>
+            Return all records in a data store matching TEntity.Name
+            </summary>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <returns></returns>
         </member>
         <member name="M:DnetIndexedDb.IndexedDbInterop.GetRange``2(System.String,``0,``0)">
             <summary>
             Return some records in a given data store by key
             </summary>
-            <typeparam name="TEntity"></typeparam>
-            <typeparam name="TKey"></typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+            <typeparam name="TKey">Type of Key Field</typeparam>
             <param name="objectStoreName"></param>
+            <param name="lowerBound"></param>
+            <param name="upperBound"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.GetRange``2(``0,``0)">
+            <summary>
+            Return some records in a data store matching TEntity.Name by key
+            </summary>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+            <typeparam name="TKey">Type of Key Field</typeparam>
             <param name="lowerBound"></param>
             <param name="upperBound"></param>
             <returns></returns>
@@ -157,9 +233,21 @@
             <summary>
             Return some records in a given data store by index
             </summary>
-            <typeparam name="TKey"></typeparam>
-            <typeparam name="TEntity"></typeparam>
+            <typeparam name="TKey">Type of Key Field</typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="objectStoreName"></param>
+            <param name="lowerBound"></param>
+            <param name="upperBound"></param>
+            <param name="dbIndex"></param>
+            <param name="isRange"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.GetByIndex``2(``0,``0,System.String,System.Boolean)">
+            <summary>
+            Return some records in a data store matching TEntity.Name by index
+            </summary>
+            <typeparam name="TKey">Type of Key Field</typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="lowerBound"></param>
             <param name="upperBound"></param>
             <param name="dbIndex"></param>
@@ -175,20 +263,46 @@
             <param name="dbIndex"></param>
             <returns></returns>
         </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.GetMaxIndex``2(System.String)">
+            <summary>
+            Returns the max value in a data store matching TEntity.Name by index
+            </summary>
+            <typeparam name="TIndex"></typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+            <param name="dbIndex"></param>
+            <returns></returns>
+        </member>
         <member name="M:DnetIndexedDb.IndexedDbInterop.GetMaxKey``1(System.String)">
             <summary>
             Returns the max value in the given data store's key
             </summary>
-            <typeparam name="TKey"></typeparam>
+            <typeparam name="TKey">Type of Key Field</typeparam>
             <param name="objectStoreName"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.GetMaxKey``2">
+            <summary>
+            Returns the max value in a data store matching TEntity.Name 
+            </summary>
+            <typeparam name="TKey">Type of Key Field</typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <returns></returns>
         </member>
         <member name="M:DnetIndexedDb.IndexedDbInterop.GetMinIndex``1(System.String,System.String)">
             <summary>
-            Returns the minimum value in the given data store's index 
+            Returns the minimum value in the given data store's index by key 
             </summary>
             <typeparam name="TIndex"></typeparam>
             <param name="objectStoreName"></param>
+            <param name="dbIndex"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.GetMinIndex``2(System.String)">
+            <summary>
+            Returns the minimum value in a data store matching TEntity.Name by index
+            </summary>
+            <typeparam name="TIndex"></typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <param name="dbIndex"></param>
             <returns></returns>
         </member>
@@ -196,8 +310,16 @@
             <summary>
             Returns the minimum value in the given data store's key 
             </summary>
-            <typeparam name="TKey"></typeparam>
+            <typeparam name="TKey">Type of Key Field</typeparam>
             <param name="objectStoreName"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.IndexedDbInterop.GetMinKey``2">
+            <summary>
+            Returns the minimum value in a data store matching TEntity.Name by key 
+            </summary>
+            <typeparam name="TKey">Type of Key Field</typeparam>
+            <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
             <returns></returns>
         </member>
     </members>

--- a/src/DnetIndexedDb/Fluent/IndexedDbDatabaseExtensions.cs
+++ b/src/DnetIndexedDb/Fluent/IndexedDbDatabaseExtensions.cs
@@ -61,5 +61,28 @@ namespace DnetIndexedDb.Fluent
 
             return store;
         }
+
+        /// <summary>
+        /// Adds a new store named after <T> and adds Key and Indexes based on IndexedDbKey and IndexedDbIndex Attributes
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        public static IndexedDbStore AddStore<T>(this IndexedDbDatabaseModel model)
+        {
+            if (model.Stores == null)
+            {
+                model.Stores = new List<IndexedDbStore>();
+            }
+
+            var store = new IndexedDbStore();
+            store.Name = typeof(T).Name;
+
+            store.SetupFrom<T>();
+
+            model.Stores.Add(store);
+
+            return store;
+        }
     }
 }

--- a/src/DnetIndexedDb/Fluent/IndexedDbDatabaseExtensions.cs
+++ b/src/DnetIndexedDb/Fluent/IndexedDbDatabaseExtensions.cs
@@ -42,6 +42,28 @@ namespace DnetIndexedDb.Fluent
         }
 
         /// <summary>
+        /// Sets Database UseKeyGenerator Property to true
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        public static IndexedDbDatabaseModel UseKeyGenerator(this IndexedDbDatabaseModel model)
+        {
+            model.UseKeyGenerator = true;
+            return model;
+        }
+
+        /// <summary>
+        /// Sets Database UseKeyGenerator Property to given value
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        public static IndexedDbDatabaseModel UseKeyGenerator(this IndexedDbDatabaseModel model, bool value)
+        {
+            model.UseKeyGenerator = value;
+            return model;
+        }
+
+        /// <summary>
         /// Creates a new IndexedDbStore and adds it to the Database Model
         /// </summary>
         /// <param name="model"></param>
@@ -63,12 +85,12 @@ namespace DnetIndexedDb.Fluent
         }
 
         /// <summary>
-        /// Adds a new store named after <T> and adds Key and Indexes based on IndexedDbKey and IndexedDbIndex Attributes
+        /// Adds a new store named TEntity.Name and adds Key and Indexes based on IndexedDbKey and IndexedDbIndex Attributes
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TEntity"></typeparam>
         /// <param name="model"></param>
         /// <returns></returns>
-        public static IndexedDbStore AddStore<T>(this IndexedDbDatabaseModel model)
+        public static IndexedDbStore AddStore<TEntity>(this IndexedDbDatabaseModel model)
         {
             if (model.Stores == null)
             {
@@ -76,9 +98,33 @@ namespace DnetIndexedDb.Fluent
             }
 
             var store = new IndexedDbStore();
-            store.Name = typeof(T).Name;
+            store.Name = typeof(TEntity).Name;
 
-            store.SetupFrom<T>();
+            store.SetupFrom<TEntity>();
+
+            model.Stores.Add(store);
+
+            return store;
+        }
+
+        /// <summary>
+        /// Adds a new store and adds Key and Indexes based on IndexedDbKey and IndexedDbIndex Attributes
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="model"></param>
+        /// <param name="storeName"></param>
+        /// <returns></returns>
+        public static IndexedDbStore AddStore<TEntity>(this IndexedDbDatabaseModel model, string storeName)
+        {
+            if (model.Stores == null)
+            {
+                model.Stores = new List<IndexedDbStore>();
+            }
+
+            var store = new IndexedDbStore();
+            store.Name = storeName;
+
+            store.SetupFrom<TEntity>();
 
             model.Stores.Add(store);
 

--- a/src/DnetIndexedDb/Fluent/IndexedDbStoreExtensions.cs
+++ b/src/DnetIndexedDb/Fluent/IndexedDbStoreExtensions.cs
@@ -93,7 +93,7 @@ namespace DnetIndexedDb.Fluent
         }
 
         /// <summary>
-        /// Adds Key and Indexes to Store based on IndexedDbKey and IndexedDbIndex Attributes on propertyis in <T>
+        /// Adds Key and Indexes to Store based on IndexedDbKey and IndexedDbIndex Attributes on properties in Type T
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="store"></param>

--- a/src/DnetIndexedDb/Fluent/IndexedDbStoreExtensions.cs
+++ b/src/DnetIndexedDb/Fluent/IndexedDbStoreExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using DnetIndexedDb.Models;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 
 namespace DnetIndexedDb.Fluent
 {
@@ -27,7 +29,7 @@ namespace DnetIndexedDb.Fluent
         /// <returns>Given IndexedDbStore Instance</returns>
         public static IndexedDbStore WithAutoIncrementingKey(this IndexedDbStore store, string name)
         {
-            return store.CreateKey(name, autoIncrement:true);
+            return store.CreateKey(name, autoIncrement: true);
         }
 
         private static IndexedDbStore CreateKey(this IndexedDbStore store, string name, bool autoIncrement)
@@ -81,13 +83,51 @@ namespace DnetIndexedDb.Fluent
             return store;
         }
 
-        public static string ToCamelCase(this string str)
+        private static string ToCamelCase(this string str)
         {
             if (!string.IsNullOrEmpty(str) && str.Length > 1)
             {
                 return char.ToLowerInvariant(str[0]) + str.Substring(1);
             }
             return str;
+        }
+
+        /// <summary>
+        /// Adds Key and Indexes to Store based on IndexedDbKey and IndexedDbIndex Attributes on propertyis in <T>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="store"></param>
+        /// <returns></returns>
+        public static IndexedDbStore SetupFrom<T>(this IndexedDbStore store)
+        {
+            store.Indexes = null;
+
+            var type = typeof(T);
+            var props = type.GetProperties();
+
+            foreach (var prop in props)
+            {
+                var keyAttribute = prop.GetCustomAttribute<IndexDbKeyAttribute>();
+                var indexAttribute = prop.GetCustomAttribute<IndexDbIndexAttribute>();
+
+                if (keyAttribute is not null)
+                {
+                    store.CreateKey(prop.Name, keyAttribute.AutoIncrement);
+                    store.CreateIndex(prop.Name, new IndexedDbIndexParameter() { Unique = keyAttribute.Unique });
+                }
+
+                if (indexAttribute is not null)
+                {
+                    store.CreateIndex(prop.Name, new IndexedDbIndexParameter() { Unique = indexAttribute.Unique });
+                }
+            }
+
+            if(store.Key == null)
+            {
+                throw new System.Exception($"No IndexDbKey Found on Property Attributes in Class {type.Name}");
+            }
+
+            return store;
         }
     }
 }

--- a/src/DnetIndexedDb/IndexedDbInterop.cs
+++ b/src/DnetIndexedDb/IndexedDbInterop.cs
@@ -9,6 +9,8 @@ namespace DnetIndexedDb
 {
     public class IndexedDbInterop
     {
+        private const string MaxExtent = "Max";
+        private const string MinExtent = "Min";
         private readonly IJSRuntime _jsRuntime;
 
         private readonly IndexedDbOptions _indexedDbDatabaseOptions;
@@ -65,7 +67,7 @@ namespace DnetIndexedDb
         /// <summary>
         /// Add records to a given data store
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="objectStoreName"></param>
         /// <param name="items"></param>
         /// <returns></returns>
@@ -75,9 +77,9 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Add records to a data store matching <TEntity>.Name
+        /// Add records to a data store matching TEntity.Name
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="items"></param>
         /// <returns></returns>
         public async ValueTask<string> AddItems<TEntity>(List<TEntity> items)
@@ -88,7 +90,7 @@ namespace DnetIndexedDb
         /// <summary>
         /// Update records in a given data store
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="objectStoreName"></param>
         /// <param name="items"></param>
         /// <returns></returns>
@@ -98,9 +100,9 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Update records in a data store matching <TEntity>.Name
+        /// Update records in a data store matching TEntity.Name
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="items"></param>
         /// <returns></returns>
         public async ValueTask<string> UpdateItems<TEntity>(List<TEntity> items)
@@ -111,7 +113,7 @@ namespace DnetIndexedDb
         /// <summary>
         /// Update records in a given data store by key
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="objectStoreName"></param>
         /// <param name="items"></param>
         /// <param name="keys"></param>
@@ -122,9 +124,9 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Update records in a data store matching <TEntity>.Name by key
+        /// Update records in a data store matching TEntity.Name by key
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="items"></param>
         /// <param name="keys"></param>
         /// <returns></returns>
@@ -136,8 +138,8 @@ namespace DnetIndexedDb
         /// <summary>
         /// Return a record in a given data store by its key
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
-        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
         /// <param name="key"></param>
         /// <param name="objectStoreName"></param>
         /// <returns></returns>
@@ -147,10 +149,10 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Return a record in a data store matching <TEntity>.Name by key
+        /// Return a record in a data store matching TEntity.Name by key
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
-        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
         /// <param name="key"></param>
         /// <returns></returns>
         public async ValueTask<TEntity> GetByKey<TKey, TEntity>(TKey key)
@@ -161,7 +163,7 @@ namespace DnetIndexedDb
         /// <summary>
         /// Delete a record in a given data store by its key
         /// </summary>
-        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
         /// <param name="key"></param>
         /// <param name="objectStoreName"></param>
         /// <returns></returns>
@@ -171,10 +173,10 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Delete a record in a data store matching <TEntity>.Name by key
+        /// Delete a record in a data store matching TEntity.Name by key
         /// </summary>
-        /// <typeparam name="TKey"></typeparam>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="key"></param>
         /// <returns></returns>
         public async ValueTask<string> DeleteByKey<TKey, TEntity>(TKey key)
@@ -193,9 +195,9 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Delete all records in a data store matching <TEntity>.Name
+        /// Delete all records in a data store matching TEntity.Name
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <returns></returns>
         public async ValueTask<string> DeleteAll<TEntity>()
         {
@@ -205,7 +207,7 @@ namespace DnetIndexedDb
         /// <summary>
         /// Return all records in a given data store
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="objectStoreName"></param>
         /// <returns></returns>
         public async ValueTask<List<TEntity>> GetAll<TEntity>(string objectStoreName)
@@ -214,9 +216,9 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Return all records in a data store matching <TEntity>.Name
+        /// Return all records in a data store matching TEntity.Name
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <returns></returns>
         public async ValueTask<List<TEntity>> GetAll<TEntity>()
         {
@@ -226,8 +228,8 @@ namespace DnetIndexedDb
         /// <summary>
         /// Return some records in a given data store by key
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
-        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
         /// <param name="objectStoreName"></param>
         /// <param name="lowerBound"></param>
         /// <param name="upperBound"></param>
@@ -238,10 +240,10 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Return some records in a data store matching <TEntity>.Name by key
+        /// Return some records in a data store matching TEntity.Name by key
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
-        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
         /// <param name="lowerBound"></param>
         /// <param name="upperBound"></param>
         /// <returns></returns>
@@ -253,8 +255,8 @@ namespace DnetIndexedDb
         /// <summary>
         /// Return some records in a given data store by index
         /// </summary>
-        /// <typeparam name="TKey"></typeparam>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="objectStoreName"></param>
         /// <param name="lowerBound"></param>
         /// <param name="upperBound"></param>
@@ -267,10 +269,10 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Return some records in a data store matching <TEntity>.Name by index
+        /// Return some records in a data store matching TEntity.Name by index
         /// </summary>
-        /// <typeparam name="TKey"></typeparam>
-        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
         /// <param name="lowerBound"></param>
         /// <param name="upperBound"></param>
         /// <param name="dbIndex"></param>
@@ -290,22 +292,45 @@ namespace DnetIndexedDb
         /// <returns></returns>
         public async ValueTask<TIndex> GetMaxIndex<TIndex>(string objectStoreName, string dbIndex)
         {
-            return await GetExtent<TIndex>(objectStoreName, dbIndex, "Max");
+            return await GetExtent<TIndex>(objectStoreName, dbIndex, MaxExtent);
+        }
+
+        /// <summary>
+        /// Returns the max value in a data store matching TEntity.Name by index
+        /// </summary>
+        /// <typeparam name="TIndex"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+        /// <param name="dbIndex"></param>
+        /// <returns></returns>
+        public async ValueTask<TIndex> GetMaxIndex<TIndex, TEntity>(string dbIndex)
+        {
+            return await GetExtent<TIndex>(typeof(TEntity).Name, dbIndex, MaxExtent);
         }
 
         /// <summary>
         /// Returns the max value in the given data store's key
         /// </summary>
-        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
         /// <param name="objectStoreName"></param>
         /// <returns></returns>
         public async ValueTask<TKey> GetMaxKey<TKey>(string objectStoreName)
         {
-            return await GetExtent<TKey>(objectStoreName, null, "Max");
+            return await GetExtent<TKey>(objectStoreName, null, MaxExtent);
         }
 
         /// <summary>
-        /// Returns the minimum value in the given data store's index 
+        /// Returns the max value in a data store matching TEntity.Name 
+        /// </summary>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+        /// <returns></returns>
+        public async ValueTask<TKey> GetMaxKey<TKey, TEntity>()
+        {
+            return await GetExtent<TKey>(typeof(TEntity).Name, null, MaxExtent);
+        }
+
+        /// <summary>
+        /// Returns the minimum value in the given data store's index by key 
         /// </summary>
         /// <typeparam name="TIndex"></typeparam>
         /// <param name="objectStoreName"></param>
@@ -313,18 +338,41 @@ namespace DnetIndexedDb
         /// <returns></returns>
         public async ValueTask<TIndex> GetMinIndex<TIndex>(string objectStoreName, string dbIndex)
         {
-            return await GetExtent<TIndex>(objectStoreName, dbIndex, "Min");
+            return await GetExtent<TIndex>(objectStoreName, dbIndex, MinExtent);
+        }
+
+        /// <summary>
+        /// Returns the minimum value in a data store matching TEntity.Name by index
+        /// </summary>
+        /// <typeparam name="TIndex"></typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+        /// <param name="dbIndex"></param>
+        /// <returns></returns>
+        public async ValueTask<TIndex> GetMinIndex<TIndex, TEntity>(string dbIndex)
+        {
+            return await GetExtent<TIndex>(typeof(TEntity).Name, dbIndex, MinExtent);
         }
 
         /// <summary>
         /// Returns the minimum value in the given data store's key 
         /// </summary>
-        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
         /// <param name="objectStoreName"></param>
         /// <returns></returns>
         public async ValueTask<TKey> GetMinKey<TKey>(string objectStoreName)
         {
-            return await GetExtent<TKey>(objectStoreName, null, "Min");
+            return await GetExtent<TKey>(objectStoreName, null, MinExtent);
+        }
+
+        /// <summary>
+        /// Returns the minimum value in a data store matching TEntity.Name by key 
+        /// </summary>
+        /// <typeparam name="TKey">Type of Key Field</typeparam>
+        /// <typeparam name="TEntity">Type of Objects in Data Store</typeparam>
+        /// <returns></returns>
+        public async ValueTask<TKey> GetMinKey<TKey, TEntity>()
+        {
+            return await GetExtent<TKey>(typeof(TEntity).Name, null, MinExtent);
         }
 
         private async ValueTask<T> GetExtent<T>(string objectStoreName, string dbIndex, string extentType)

--- a/src/DnetIndexedDb/IndexedDbInterop.cs
+++ b/src/DnetIndexedDb/IndexedDbInterop.cs
@@ -75,6 +75,17 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
+        /// Add records to a data store matching <TEntity>.Name
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="items"></param>
+        /// <returns></returns>
+        public async ValueTask<string> AddItems<TEntity>(List<TEntity> items)
+        {
+            return await _jsRuntime.InvokeAsync<string>("dnetindexeddbinterop.addItems", _indexedDbDatabaseModel, typeof(TEntity).Name, items);
+        }
+
+        /// <summary>
         /// Update records in a given data store
         /// </summary>
         /// <typeparam name="TEntity"></typeparam>
@@ -87,7 +98,18 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
-        /// Update records in a given data store by keys
+        /// Update records in a data store matching <TEntity>.Name
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="items"></param>
+        /// <returns></returns>
+        public async ValueTask<string> UpdateItems<TEntity>(List<TEntity> items)
+        {
+            return await _jsRuntime.InvokeAsync<string>("dnetindexeddbinterop.updateItems", _indexedDbDatabaseModel, typeof(TEntity).Name, items);
+        }
+
+        /// <summary>
+        /// Update records in a given data store by key
         /// </summary>
         /// <typeparam name="TEntity"></typeparam>
         /// <param name="objectStoreName"></param>
@@ -97,6 +119,18 @@ namespace DnetIndexedDb
         public async ValueTask<string> UpdateItemsByKey<TEntity>(string objectStoreName, List<TEntity> items, List<int> keys)
         {
             return await _jsRuntime.InvokeAsync<string>("dnetindexeddbinterop.updateItemsByKey", _indexedDbDatabaseModel, objectStoreName, items, keys);
+        }
+
+        /// <summary>
+        /// Update records in a data store matching <TEntity>.Name by key
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="items"></param>
+        /// <param name="keys"></param>
+        /// <returns></returns>
+        public async ValueTask<string> UpdateItemsByKey<TEntity>(List<TEntity> items, List<int> keys)
+        {
+            return await _jsRuntime.InvokeAsync<string>("dnetindexeddbinterop.updateItemsByKey", _indexedDbDatabaseModel, typeof(TEntity).Name, items, keys);
         }
 
         /// <summary>
@@ -113,6 +147,18 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
+        /// Return a record in a data store matching <TEntity>.Name by key
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TKey"></typeparam>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public async ValueTask<TEntity> GetByKey<TKey, TEntity>(TKey key)
+        {
+            return await _jsRuntime.InvokeAsync<TEntity>("dnetindexeddbinterop.getByKey", _indexedDbDatabaseModel, typeof(TEntity).Name, key);
+        }
+
+        /// <summary>
         /// Delete a record in a given data store by its key
         /// </summary>
         /// <typeparam name="TKey"></typeparam>
@@ -122,6 +168,18 @@ namespace DnetIndexedDb
         public async ValueTask<string> DeleteByKey<TKey>(string objectStoreName, TKey key)
         {
             return await _jsRuntime.InvokeAsync<string>("dnetindexeddbinterop.deleteByKey", _indexedDbDatabaseModel, objectStoreName, key);
+        }
+
+        /// <summary>
+        /// Delete a record in a data store matching <TEntity>.Name by key
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public async ValueTask<string> DeleteByKey<TKey, TEntity>(TKey key)
+        {
+            return await _jsRuntime.InvokeAsync<string>("dnetindexeddbinterop.deleteByKey", _indexedDbDatabaseModel, typeof(TEntity).Name, key);
         }
 
         /// <summary>
@@ -135,6 +193,16 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
+        /// Delete all records in a data store matching <TEntity>.Name
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <returns></returns>
+        public async ValueTask<string> DeleteAll<TEntity>()
+        {
+            return await _jsRuntime.InvokeAsync<string>("dnetindexeddbinterop.deleteAll", _indexedDbDatabaseModel, typeof(TEntity).Name);
+        }
+
+        /// <summary>
         /// Return all records in a given data store
         /// </summary>
         /// <typeparam name="TEntity"></typeparam>
@@ -143,6 +211,16 @@ namespace DnetIndexedDb
         public async ValueTask<List<TEntity>> GetAll<TEntity>(string objectStoreName)
         {
             return await _jsRuntime.InvokeAsync<List<TEntity>>("dnetindexeddbinterop.getAll", _indexedDbDatabaseModel, objectStoreName);
+        }
+
+        /// <summary>
+        /// Return all records in a data store matching <TEntity>.Name
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <returns></returns>
+        public async ValueTask<List<TEntity>> GetAll<TEntity>()
+        {
+            return await _jsRuntime.InvokeAsync<List<TEntity>>("dnetindexeddbinterop.getAll", _indexedDbDatabaseModel, typeof(TEntity).Name);
         }
 
         /// <summary>
@@ -160,6 +238,19 @@ namespace DnetIndexedDb
         }
 
         /// <summary>
+        /// Return some records in a data store matching <TEntity>.Name by key
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TKey"></typeparam>
+        /// <param name="lowerBound"></param>
+        /// <param name="upperBound"></param>
+        /// <returns></returns>
+        public async ValueTask<List<TEntity>> GetRange<TKey, TEntity>(TKey lowerBound, TKey upperBound)
+        {
+            return await _jsRuntime.InvokeAsync<List<TEntity>>("dnetindexeddbinterop.getRange", _indexedDbDatabaseModel, typeof(TEntity).Name, lowerBound, upperBound);
+        }
+
+        /// <summary>
         /// Return some records in a given data store by index
         /// </summary>
         /// <typeparam name="TKey"></typeparam>
@@ -173,6 +264,21 @@ namespace DnetIndexedDb
         public async ValueTask<List<TEntity>> GetByIndex<TKey, TEntity>(string objectStoreName, TKey lowerBound, TKey upperBound, string dbIndex, bool isRange)
         {
             return await _jsRuntime.InvokeAsync<List<TEntity>>("dnetindexeddbinterop.getByIndex", _indexedDbDatabaseModel, objectStoreName, lowerBound, upperBound, dbIndex, isRange);
+        }
+
+        /// <summary>
+        /// Return some records in a data store matching <TEntity>.Name by index
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="lowerBound"></param>
+        /// <param name="upperBound"></param>
+        /// <param name="dbIndex"></param>
+        /// <param name="isRange"></param>
+        /// <returns></returns>
+        public async ValueTask<List<TEntity>> GetByIndex<TKey, TEntity>(TKey lowerBound, TKey upperBound, string dbIndex, bool isRange)
+        {
+            return await _jsRuntime.InvokeAsync<List<TEntity>>("dnetindexeddbinterop.getByIndex", _indexedDbDatabaseModel, typeof(TEntity).Name, lowerBound, upperBound, dbIndex, isRange);
         }
 
         /// <summary>

--- a/src/DnetIndexedDb/Models/IndexedDbDatabase.cs
+++ b/src/DnetIndexedDb/Models/IndexedDbDatabase.cs
@@ -1,9 +1,0 @@
-﻿namespace DnetIndexedDb.Models
-{
-    public class IndexedDbDatabase
-    {
-        public string Name { get; set; }
-
-        public long Version { get; set; }
-    }
-}


### PR DESCRIPTION
This is an alternative way to configure the database models that allows for simpler interop calls as well.  Removes a lot of the chances of error in typing out strings in the interop calls.  Mentioned in Discussion #26.

## Configuration Changes

`[IndexDbKey]` and `[IndexDbIndex]` Property Attributes can be used to configure the database based on the given class.  
A DataStore will be created matching the name of the class.

```CSharp
    public class TableFieldDto
    {
        [IndexDbKey(AutoIncrement = true)]
        public int? TableFieldId { get; set; }
        [IndexDbIndex]
        public string TableName { get; set; }
        [IndexDbIndex]
        public string FieldVisualName { get; set; }
        [IndexDbIndex]
        public string AttachedProperty { get; set; }
        [IndexDbIndex]
        public bool IsLink { get; set; }
        [IndexDbIndex]
        public int MemberOf { get; set; }
        [IndexDbIndex]
        public int Width { get; set; }
        [IndexDbIndex]
        public string TextAlignClass { get; set; }
        [IndexDbIndex]
        public bool Hide { get; set; }
        [IndexDbIndex]
        public string Type { get; set; }
    }

...

    var indexedDbDatabaseModel = new IndexedDbDatabaseModel()
        .WithName("TestAttributes")
        .WithVersion(1);

    indexedDbDatabaseModel.AddStore<TableFieldDto>();
```

## Interop Call Changes

I added an overload of each DataStore level function.

They can be used when the Class name and DataStore name match and the `objectStoreName` variable that is usually passed in is now inferred from the Class Type Name.

```ValueTask<TEntity> GetByKey<TKey, TEntity>(string objectStoreName, TKey key)```

```ValueTask<TEntity> GetByKey<TKey, TEntity>(TKey key)```

```CSharp
// Manually set DataStore name
 var result = await GridColumnDataIndexedDb.GetByKey<int, TableFieldDto>("tableField", 11);

// DataStore name inferred from class 
 var result = await GridColumnDataIndexedDb.GetByKey<int, TableFieldDto>(11);
```


### Notes
 - Examples Updated
 - ReadMe Updates
 - Deleted the DnetIndexedDb/Models/IndexedDbDatabase.cs file that was never used but was referenced in the Readme as a class that needs setup