### PR TITLE
Minorfixes

### DIFF
--- a/samples/ServerSide/Pages/Index.razor
+++ b/samples/ServerSide/Pages/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/"
+@page "/"
 @using DnetIndexedDbServer.Infrastructure
 @using DnetIndexedDbServer.Infrastructure.Entities
 @inject IHttpClientFactory ClientFactory
@@ -143,13 +143,13 @@
 
         var db1Result9 = await GridColumnDataIndexedDb2.GetByIndex<int?, TableFieldDto>(11, null, "tableFieldId", false);
 
-        var testMaxKeyEmpty = await GridColumnDataIndexedDb.GetMaxKey<int, TableFieldDto>();
+        var testMaxKeyEmpty = await GridColumnDataIndexedDb2.GetMaxKey<int, TableFieldDto>();
 
-        var testMinKeyEmpty = await GridColumnDataIndexedDb.GetMinKey<int, TableFieldDto>();
+        var testMinKeyEmpty = await GridColumnDataIndexedDb2.GetMinKey<int, TableFieldDto>();
 
-        var testMaxIndexEmpty = await GridColumnDataIndexedDb.GetMaxIndex<string, TableFieldDto>("tableFieldId");
+        var testMaxIndexEmpty = await GridColumnDataIndexedDb2.GetMaxIndex<int, TableFieldDto>("tableFieldId");
 
-        var testMinIndexEmpty = await GridColumnDataIndexedDb.GetMinIndex<string, TableFieldDto>("tableFieldId");
+        var testMinIndexEmpty = await GridColumnDataIndexedDb2.GetMinIndex<int, TableFieldDto>("tableFieldId");
 
         var db1Result10 = await GridColumnDataIndexedDb2.DeleteAll<TableFieldDto>();
 

--- a/samples/ServerSide/wwwroot/css/site.css
+++ b/samples/ServerSide/wwwroot/css/site.css
@@ -737,3 +737,22 @@ body {
   color: #38455b;
   border: 1px solid #eee;
   padding: 2px 5px; }
+
+#blazor-error-ui {
+  background: lightyellow;
+  bottom: 0;
+  box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+  display: none;
+  left: 0;
+  padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+  position: fixed;
+  width: 100%;
+  z-index: 1000;
+}
+
+  #blazor-error-ui .dismiss {
+    cursor: pointer;
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+  }


### PR DESCRIPTION
`TestAttributes` now consistently uses `GridColumnDataIndexedDb2`.

Also added `blazor-error-ui` from `dotnet new blazorserver`'s `site.css`. Now the error notification at the bottom of the sample proj only appears when appropriate.