### PR TITLE
Fix XML Documentation path on csproj

### DIFF
--- a/src/DnetIndexedDb/DnetIndexedDb.csproj
+++ b/src/DnetIndexedDb/DnetIndexedDb.csproj
@@ -18,8 +18,8 @@
     </PackageReleaseNotes>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>D:\Projects\DnetIndexedDb\src\DnetIndexedDb\DnetIndexedDb.xml</DocumentationFile>
+  <PropertyGroup>
+    <DocumentationFile>.\DnetIndexedDb.xml</DocumentationFile>
   </PropertyGroup>
 
 

--- a/src/DnetIndexedDb/DnetIndexedDb.xml
+++ b/src/DnetIndexedDb/DnetIndexedDb.xml
@@ -28,6 +28,20 @@
             <param name="id"></param>
             <returns></returns>
         </member>
+        <member name="M:DnetIndexedDb.Fluent.IndexedDbDatabaseExtensions.UseKeyGenerator(DnetIndexedDb.Models.IndexedDbDatabaseModel)">
+            <summary>
+            Sets Database UseKeyGenerator Property to true
+            </summary>
+            <param name="model"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.Fluent.IndexedDbDatabaseExtensions.UseKeyGenerator(DnetIndexedDb.Models.IndexedDbDatabaseModel,System.Boolean)">
+            <summary>
+            Sets Database UseKeyGenerator Property to given value
+            </summary>
+            <param name="model"></param>
+            <returns></returns>
+        </member>
         <member name="M:DnetIndexedDb.Fluent.IndexedDbDatabaseExtensions.AddStore(DnetIndexedDb.Models.IndexedDbDatabaseModel,System.String)">
             <summary>
             Creates a new IndexedDbStore and adds it to the Database Model
@@ -36,7 +50,23 @@
             <param name="name"></param>
             <returns></returns>
         </member>
-        <!-- Badly formed XML comment ignored for member "M:DnetIndexedDb.Fluent.IndexedDbDatabaseExtensions.AddStore``1(DnetIndexedDb.Models.IndexedDbDatabaseModel)" -->
+        <member name="M:DnetIndexedDb.Fluent.IndexedDbDatabaseExtensions.AddStore``1(DnetIndexedDb.Models.IndexedDbDatabaseModel)">
+            <summary>
+            Adds a new store named TEntity.Name and adds Key and Indexes based on IndexedDbKey and IndexedDbIndex Attributes
+            </summary>
+            <typeparam name="TEntity"></typeparam>
+            <param name="model"></param>
+            <returns></returns>
+        </member>
+        <member name="M:DnetIndexedDb.Fluent.IndexedDbDatabaseExtensions.AddStore``1(DnetIndexedDb.Models.IndexedDbDatabaseModel,System.String)">
+            <summary>
+            Adds a new store and adds Key and Indexes based on IndexedDbKey and IndexedDbIndex Attributes
+            </summary>
+            <typeparam name="TEntity"></typeparam>
+            <param name="model"></param>
+            <param name="storeName"></param>
+            <returns></returns>
+        </member>
         <member name="M:DnetIndexedDb.Fluent.IndexedDbStoreExtensions.WithKey(DnetIndexedDb.Models.IndexedDbStore,System.String)">
             <summary>
             Add non-auto-incrementing key to store.


### PR DESCRIPTION
Hi,
I made two little changes to csproj file:

1. The .xml documentation path was pointing to an absolute path (D:\...\..\DtnetIndexedDb.xml), I've just change this path pointing to the folder containing the .csproj
2. I removed the Condition on the PropertyGroup of the DocumentationFile. In this way the documentation will be created anyway and will be included in the NuGet Package as well.